### PR TITLE
add cainjector

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,17 @@ go get -u sigs.k8s.io/kustomize
 
 ## Upstream Manifests
 
-the proposed [way](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html) is using helm to generate manifests from upstream. 
+the proposed [way](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html) is using helm to generate manifests from upstream.
 
 ```
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 helm fetch 'jetstack/cert-manager'
-helm template --namespace kube-system --name cert-manager --set webhook.enabled=false --set cainjector.enabled=false cert-manager-v0.9.1.tgz
+helm template --namespace kube-system --name cert-manager --set webhook.enabled=false cert-manager-v0.9.1.tgz
 ```
 
 In order to properly update the base one should roughly follow the below steps
+
 1. Get upstream manifests via helm templates
 2. Split it into cluster and namespaced resources
 3. Extract cluster role bindings and update examples

--- a/cluster/cert-manager-clusterrole.yaml
+++ b/cluster/cert-manager-clusterrole.yaml
@@ -1,3 +1,35 @@
+# Source: cert-manager/charts/cainjector/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cainjector-v0.9.1
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps", "events"]
+    verbs: ["get", "create", "update", "patch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "update"]
+---
 # Source: cert-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -6,7 +38,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 rules:
@@ -16,7 +48,6 @@ rules:
     verbs: ["get", "create", "update", "patch"]
 
 ---
-
 # Issuer controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -25,7 +56,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 rules:
@@ -43,7 +74,6 @@ rules:
     verbs: ["create", "patch"]
 
 ---
-
 # ClusterIssuer controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -52,7 +82,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 rules:
@@ -70,7 +100,6 @@ rules:
     verbs: ["create", "patch"]
 
 ---
-
 # Certificates controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -79,15 +108,28 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
+    resources:
+      [
+        "certificates",
+        "certificates/status",
+        "certificaterequests",
+        "certificaterequests/status",
+      ]
     verbs: ["update"]
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers", "orders"]
+    resources:
+      [
+        "certificates",
+        "certificaterequests",
+        "clusterissuers",
+        "issuers",
+        "orders",
+      ]
     verbs: ["get", "list", "watch"]
   # We require these rules to support users with the OwnerReferencesPermissionEnforcement
   # admission controller enabled:
@@ -106,7 +148,6 @@ rules:
     verbs: ["create", "patch"]
 
 ---
-
 # Orders controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -115,7 +156,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 rules:
@@ -142,7 +183,6 @@ rules:
     verbs: ["create", "patch"]
 
 ---
-
 # Challenges controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -151,7 +191,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 rules:
@@ -190,7 +230,6 @@ rules:
     verbs: ["get", "list", "watch"]
 
 ---
-
 # ingress-shim controller role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -199,7 +238,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 rules:
@@ -207,7 +246,8 @@ rules:
     resources: ["certificates", "certificaterequests"]
     verbs: ["create", "update", "delete"]
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
+    resources:
+      ["certificates", "certificaterequests", "issuers", "clusterissuers"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["extensions"]
     resources: ["ingresses"]
@@ -223,7 +263,6 @@ rules:
     verbs: ["create", "patch"]
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -231,7 +270,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -243,7 +282,6 @@ rules:
     verbs: ["get", "list", "watch"]
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -251,7 +289,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/cluster/kustomization.yaml
+++ b/cluster/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- cert-manager-clusterrole.yaml
-- cert-manager-crds.yaml
+  - cert-manager-clusterrole.yaml
+  - cert-manager-crds.yaml

--- a/example/cert-manager-clusterrolebinding.yaml
+++ b/example/cert-manager-clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 roleRef:
@@ -19,7 +19,6 @@ subjects:
     kind: ServiceAccount
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -27,7 +26,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 roleRef:
@@ -41,7 +40,6 @@ subjects:
     kind: ServiceAccount
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -49,7 +47,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 roleRef:
@@ -63,7 +61,6 @@ subjects:
     kind: ServiceAccount
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -71,7 +68,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 roleRef:
@@ -85,7 +82,6 @@ subjects:
     kind: ServiceAccount
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -93,7 +89,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 roleRef:
@@ -107,7 +103,6 @@ subjects:
     kind: ServiceAccount
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -115,7 +110,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 roleRef:
@@ -129,7 +124,6 @@ subjects:
     kind: ServiceAccount
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -137,7 +131,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Tiller
     helm.sh/chart: cert-manager-v0.9.1
 roleRef:
@@ -146,6 +140,27 @@ roleRef:
   name: cert-manager-controller-ingress-shim
 subjects:
   - name: cert-manager
+    # Placeholder, patch with the namespace value of Deployment/ServiceAccount
+    namespace: "example"
+    kind: ServiceAccount
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cainjector-v0.9.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-cainjector
+subjects:
+  - name: cert-manager-cainjector
     # Placeholder, patch with the namespace value of Deployment/ServiceAccount
     namespace: "example"
     kind: ServiceAccount

--- a/namespaced/cert-manager-cainjector.yaml
+++ b/namespaced/cert-manager-cainjector.yaml
@@ -1,0 +1,55 @@
+# Source: cert-manager/charts/cainjector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cainjector-v0.9.1
+---
+# Source: cert-manager/charts/cainjector/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cainjector-v0.9.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cainjector
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/managed-by: Tiller
+  template:
+    metadata:
+      labels:
+        app: cainjector
+        app.kubernetes.io/name: cainjector
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/managed-by: Tiller
+        helm.sh/chart: cainjector-v0.9.1
+      annotations:
+    spec:
+      serviceAccountName: cert-manager-cainjector
+      containers:
+        - name: cainjector
+          image: "quay.io/jetstack/cert-manager-cainjector:v0.9.1"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=2
+            - --leader-election-namespace=$(POD_NAMESPACE)
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources: {}

--- a/namespaced/kustomization.yaml
+++ b/namespaced/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- cert-manager.yaml
+  - cert-manager-cainjector.yaml
+  - cert-manager.yaml


### PR DESCRIPTION
The new version of OPA gatekeeper properly supports managing the webhook ourselves, but that requires the ca injector to update the ca bundle.